### PR TITLE
Fix mkdocs deprecation issue and tidied mkdocs config

### DIFF
--- a/lib/docker/docker/mkdocs.yml
+++ b/lib/docker/docker/mkdocs.yml
@@ -1,17 +1,21 @@
-site_name: docker-py Documentation
-site_description: An API client for Docker written in Python
-site_favicon: favicon_whale.png
-site_url: http://docker-py.readthedocs.org
-repo_url: https://github.com/docker/docker-py/
-theme: readthedocs
-pages:
-- Home: index.md
-- Client API: api.md
-- Port Bindings: port-bindings.md
-- Using Volumes: volumes.md
-- Using TLS: tls.md
-- Host devices: host-devices.md
-- Host configuration: hostconfig.md
-- Using with boot2docker: boot2docker.md
-- Change Log: change_log.md
-- Contributing: contributing.md
+site_name:           docker-py Documentation
+
+site_description:    An API client for Docker written in Python
+site_favicon:        favicon_whale.png
+
+site_url:            http://docker-py.readthedocs.org
+repo_url:            https://github.com/docker/docker-py/
+
+theme:               readthedocs
+
+nav:
+  - Home:            index.md
+  - Client API:      api.md
+  - Port Bindings:   port-bindings.md
+  - Using Volumes:   volumes.md
+  - Using TLS:       tls.md
+  - Host devices:    host-devices.md
+  - Host configuration: hostconfig.md
+  - Using with boot2docker: boot2docker.md
+  - Change Log:      change_log.md
+  - Contributing:    contributing.md


### PR DESCRIPTION
First of all, mkdocs has deprecated the `pages` option in favour of a new `nav` option so I've changed that in this PR.

Also, I've tidied up the configuration to be more readable.